### PR TITLE
Don't display "unused variable" warnings.

### DIFF
--- a/Teensy_Convolution_SDR.ino
+++ b/Teensy_Convolution_SDR.ino
@@ -2904,6 +2904,8 @@ const uint16_t gradient[] = {
   , 0xF88F
 };
 
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
 PROGMEM
 void flexRamInfo(void)
 { // credit to FrankB, KurtE and defragster !


### PR DESCRIPTION
Display more important warnings only :-)